### PR TITLE
Fix references to builtin-types undefined and null

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -173,6 +173,8 @@ var clsUrl = function (cls) {
 // Return an anchor link string from a type
 var typeLink = function (type) {
     var builtins = {
+        "Undefined": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Undefined",
+        "Null": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Null",
         "Array": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
         "ArrayBuffer": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer",
         "Boolean": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",


### PR DESCRIPTION
PR fixes broken link when referencing builtin-types undefined and null.