### PR TITLE
Add support for @interface

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -104,7 +104,7 @@ function getClassInfo(data, cls) {
         for (var i = 0; i < cls.augments.length; i++) {
             var base = cls.augments[i];
 
-            inherited.cls.push(data({ kind: "class", access: { "isUndefined": true }, undocumented: { "isUndefined": true }, "longname": base }).first());
+            inherited.cls.push(data({kind: ["class", "interface"], access: {"isUndefined": true}, undocumented: {"isUndefined": true}, "longname": base}).first());
 
             all = data({
                 kind: ["member", "function", "event"],
@@ -352,12 +352,12 @@ exports.publish = function (data, opts) {
         });
 
         // Query for list of all classes
-        var classes = data({ kind: "class", access: { "isUndefined": true }, undocumented: { "isUndefined": true } }).order("longname").get();
+        var classes = data({ kind: ["class", "interface"], access: { "isUndefined": true }, undocumented: { "isUndefined": true } }).order("longname").get();
         var modules = data({ kind: "namespace", access: { "isUndefined": true }, undocumented: { "isUndefined": true } }).order("longname").get();
 
         classes = modules.concat(classes);
         classes.forEach(function (cls) {
-            cls._class = (cls.kind === "class");
+            cls._class = (cls.kind === "class" || cls.kind === "interface");
             cls._namespace = (cls.kind === "namespace");
         });
 

--- a/publish.js
+++ b/publish.js
@@ -104,7 +104,7 @@ function getClassInfo(data, cls) {
         for (var i = 0; i < cls.augments.length; i++) {
             var base = cls.augments[i];
 
-            inherited.cls.push(data({kind: ["class", "interface"], access: {"isUndefined": true}, undocumented: {"isUndefined": true}, "longname": base}).first());
+            inherited.cls.push(data({ kind: ["class", "interface"], access: { "isUndefined": true }, undocumented: { "isUndefined": true }, "longname": base }).first());
 
             all = data({
                 kind: ["member", "function", "event"],


### PR DESCRIPTION
PR fixes issues with interfaces (such as `pc.ReferenceHandler`) not being properly handled by the template.