### PR TITLE
Add some typed-array builtins

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -202,6 +202,9 @@ var typeLink = function (type) {
         "AudioContext": "https://developer.mozilla.org/en-US/docs/Web/API/AudioContext",
         "AudioBufferSourceNode": "https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode",
         "Window": "https://developer.mozilla.org/en-US/docs/Web/API/Window",
+        "Uint8Array": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
+        "Uint16Array": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
+        "Float32Array": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array",
         "*": "#" // blerg
     };
 


### PR DESCRIPTION
PR adds the following typed arrays used by the engine:
- `Uint8Array`
- `Uint16Array`
- `Float32Array`

This is necessary for one the documentation fixes included in https://github.com/playcanvas/engine/pull/1708