### PR TITLE
Add "typeof" support for referencing a class type itself (not only the instance)

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -209,6 +209,7 @@ var typeLink = function (type) {
     };
 
     var re = /Array.<(.*)>/; // regexp for arrays of types
+    var regexTypeOfPattern = /Class.<(.*)>/; // regexp for referencing the class type itself (not the instance)
     var url = null; // URL to link to type
     var name; // name of type
     var display = null; // display name of type
@@ -224,6 +225,15 @@ var typeLink = function (type) {
     if (result) {
         name = result[1];
         display = name + "[]";
+    } else {
+        display = name;
+    }
+
+    // Check for typeof
+    var regexTypeOfMatch = regexTypeOfPattern.exec(name);
+    if (regexTypeOfMatch) {
+        name = regexTypeOfMatch[1];
+        display = "typeof " + name;
     } else {
         display = name;
     }

--- a/publish.js
+++ b/publish.js
@@ -208,7 +208,7 @@ var typeLink = function (type) {
         "*": "#" // blerg
     };
 
-    var re = /Array.<(.*)>/; // regexp for arrays of types
+    var regexArrayPattern = /Array.<(.*)>/; // regexp for arrays of types
     var regexTypeOfPattern = /Class.<(.*)>/; // regexp for referencing the class type itself (not the instance)
     var url = null; // URL to link to type
     var name; // name of type
@@ -221,9 +221,9 @@ var typeLink = function (type) {
     }
 
     // Check for array
-    var result = re.exec(name);
-    if (result) {
-        name = result[1];
+    var regexArrayMatch = regexArrayPattern.exec(name);
+    if (regexArrayMatch) {
+        name = regexArrayMatch[1];
         display = name + "[]";
     } else {
         display = name;

--- a/publish.js
+++ b/publish.js
@@ -208,8 +208,9 @@ var typeLink = function (type) {
         "*": "#" // blerg
     };
 
-    var regexArrayPattern = /Array.<(.*)>/; // regexp for arrays of types
-    var regexTypeOfPattern = /Class.<(.*)>/; // regexp for referencing the class type itself (not the instance)
+    var isArray = false;
+    var regexArrayPattern = /^Array.<(.*)>$/; // regexp for arrays of types
+    var regexTypeOfPattern = /^Class.<(.*)>$/; // regexp for referencing the class type itself (not the instance)
     var url = null; // URL to link to type
     var name; // name of type
     var display = null; // display name of type
@@ -219,14 +220,14 @@ var typeLink = function (type) {
     if (type.longname) {
         name = type.longname;
     }
+    display = name;
 
     // Check for array
     var regexArrayMatch = regexArrayPattern.exec(name);
     if (regexArrayMatch) {
         name = regexArrayMatch[1];
         display = name + "[]";
-    } else {
-        display = name;
+        isArray = true;
     }
 
     // Check for typeof
@@ -234,8 +235,7 @@ var typeLink = function (type) {
     if (regexTypeOfMatch) {
         name = regexTypeOfMatch[1];
         display = "typeof " + name;
-    } else {
-        display = name;
+        if (isArray) display = "(" + display + ")[]";
     }
 
     // Check for builtin type


### PR DESCRIPTION
The PR will allow incorrect JSDoc documentation and TypeScript declarations in the PlayCanvas engine to be fixed. See https://github.com/playcanvas/engine/issues/1889 and https://github.com/playcanvas/engine/issues/1887

The following PR includes:
- Add `typeof` support for referencing a class type itself (not only the instance). Since JSDoc doesn't support `typeof T` as-is, the convention `Class<T>` will be used as specified by [tsd-jsdoc](https://github.com/englercj/tsd-jsdoc#extended-support-for-ts-features).
- Add support for a combination of special types (e.g. an array of `typeof T`/`Class<T>`s).
- Clean up some code by renaming similar local variables (related to arrays) to easier differentiate.
