### PR TITLE
Add support for recursive array/typeof

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -174,22 +174,29 @@ var clsUrl = function (cls) {
 
 };
 
-// Unwrap type (if array or class reference)
-var unwrapType = function (name) {
+// Recursively unwrap type (if array or class reference)
+var unwrapType = function (name, display) {
     var match;
+    var type;
 
     // Check for arrays of types
     match = /^Array.<(.*)>$/i.exec(name);
     if (match) {
         name = match[1];
-        display = name + "[]";
+
+        type = unwrapType(name, display);
+        display = type.display + "[]";
+        name = type.name;
     }
 
     // Check for class reference types (as opposed to class instances)
     match = /^Class.<(.*)>$/i.exec(name);
     if (match) {
         name = match[1];
-        display = "typeof(" + name + ")";
+
+        type = unwrapType(name, display);
+        display = "typeof(" + type.display + ")";
+        name = type.name;
     }
 
     return {

--- a/publish.js
+++ b/publish.js
@@ -174,6 +174,30 @@ var clsUrl = function (cls) {
 
 };
 
+// Unwrap type (if array or class reference)
+var unwrapType = function (name) {
+    var match;
+
+    // Check for arrays of types
+    match = /^Array.<(.*)>$/i.exec(name);
+    if (match) {
+        name = match[1];
+        display = name + "[]";
+    }
+
+    // Check for class reference types (as opposed to class instances)
+    match = /^Class.<(.*)>$/i.exec(name);
+    if (match) {
+        name = match[1];
+        display = "typeof(" + name + ")";
+    }
+
+    return {
+        name: name,
+        display: display || name,
+    };
+}
+
 // Return an anchor link string from a type
 var typeLink = function (type) {
     var builtins = {
@@ -208,9 +232,6 @@ var typeLink = function (type) {
         "*": "#" // blerg
     };
 
-    var isArray = false;
-    var regexArrayPattern = /^Array.<(.*)>$/; // regexp for arrays of types
-    var regexTypeOfPattern = /^Class.<(.*)>$/; // regexp for referencing the class type itself (not the instance)
     var url = null; // URL to link to type
     var name; // name of type
     var display = null; // display name of type
@@ -220,23 +241,10 @@ var typeLink = function (type) {
     if (type.longname) {
         name = type.longname;
     }
-    display = name;
 
-    // Check for array
-    var regexArrayMatch = regexArrayPattern.exec(name);
-    if (regexArrayMatch) {
-        name = regexArrayMatch[1];
-        display = name + "[]";
-        isArray = true;
-    }
-
-    // Check for typeof
-    var regexTypeOfMatch = regexTypeOfPattern.exec(name);
-    if (regexTypeOfMatch) {
-        name = regexTypeOfMatch[1];
-        display = "typeof " + name;
-        if (isArray) display = "(" + display + ")[]";
-    }
+    var unwrapped = unwrapType(name);
+    name = unwrapped.name;
+    display = unwrapped.display;
 
     // Check for builtin type
     if (builtins[name]) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/playcanvas-jsdoc-template/issues/10 and adds support for arbitrary "recursive" types (i.e. "array of arrays", "arrays of typeofs" etc).

PR changes include:
- add function `unwrapType` to recursively unwrap a type (whether array or typeof).
- call new function in `typeLink` to support recursive types.