### PR TITLE
Add support for key-value jsdoc type

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -189,6 +189,16 @@ var unwrapType = function (name, display) {
         name = type.name;
     }
 
+    // Check for key-value (aka dictionary or index signature) types
+    match = /^Object.<string,\s*(.*)>$/i.exec(name);
+    if (match) {
+        name = match[1];
+
+        type = unwrapType(name, display);
+        display = "{ [string]: " + type.display + " }";
+        name = type.name;
+    }
+
     // Check for class reference types (as opposed to class instances)
     match = /^Class.<(.*)>$/i.exec(name);
     if (match) {


### PR DESCRIPTION
PR adds proper support for types that use key-value (e.g. dictionary/index signature) syntax, as [documented in JSDoc](https://jsdoc.app/tags-type.html#jsdoc-types):

> An object with string keys and number values:
> `{Object.<string, number>}`