### PR TITLE
Skip Static Members

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -49,13 +49,23 @@ function getClassInfo(data, cls) {
                 } else {
                     // make sure we don't add duplicate properties
                     for (var p = 0; p < cls.properties.length; p++) {
-                        if (cls.properties[p].name === i.name)
+                        if (cls.properties[p].name === i.name) {
+                            //console.log("SKIP> cls.properties: ", i.longname);
                             return;
+                        }
                     }
                 }
 
                 cls.properties.push(i);
             } else if (i.scope === 'static') {
+                // make sure we don't add duplicate static members
+                for (var p = 0; p < members.length; p++) {
+                    if (members[p].name === i.name) {
+                        //console.log("SKIP> static member: ", i.longname);
+                        return;
+                    }
+                }
+
                 members.push(i);
             }
         } else if (i.kind === "function") {

--- a/publish.js
+++ b/publish.js
@@ -50,7 +50,6 @@ function getClassInfo(data, cls) {
                     // make sure we don't add duplicate properties
                     for (var p = 0; p < cls.properties.length; p++) {
                         if (cls.properties[p].name === i.name) {
-                            //console.log("SKIP> cls.properties: ", i.longname);
                             return;
                         }
                     }
@@ -61,7 +60,6 @@ function getClassInfo(data, cls) {
                 // make sure we don't add duplicate static members
                 for (var p = 0; p < members.length; p++) {
                     if (members[p].name === i.name) {
-                        //console.log("SKIP> static member: ", i.longname);
                         return;
                     }
                 }


### PR DESCRIPTION
I was running into this issue replacing JSDoc with better-docs (basically JSDoc + hacked in TypeScript support)

![image](https://user-images.githubusercontent.com/5236548/100360450-40798500-2ff9-11eb-9cab-197f992ecdd6.png)

With PR:

![image](https://user-images.githubusercontent.com/5236548/100360558-5f781700-2ff9-11eb-9d64-027a2f73c06e.png)
