### PR TITLE
Make class list sticky

### DIFF
--- a/static/scripts/interface.js
+++ b/static/scripts/interface.js
@@ -48,12 +48,12 @@ ready(function () {
 
     var onScroll = function (e) {
         // phones
-        // if (window.innerWidth <= 480) {
-        //     nav.style.top = 0;
-        //     return;
-        // }
+        if (window.innerWidth <= 480) {
+            nav.style.top = 0;
+            return;
+        }
 
-        var s = document.body.scrollTop;
+        var s = window.scrollY;
         var headerHeight = headerElement.clientHeight;
         if (s < headerHeight) {
             nav.style.top = (headerHeight - s) + "px";


### PR DESCRIPTION
Class list (left panel) has been offset when page is scrolled down, this PR fixes it by making it to stick to the top of the screen.

Before:
![image](https://user-images.githubusercontent.com/636263/102937465-e1514800-44b2-11eb-9359-b1ab80aa85ad.png)

After:
![image](https://user-images.githubusercontent.com/636263/102937492-faf28f80-44b2-11eb-8387-8a740994e95a.png)
