### PR TITLE
Added support for `hideconstructor` tag

### DIFF
--- a/tmpl/class.tmpl
+++ b/tmpl/class.tmpl
@@ -173,10 +173,12 @@
     {{/if}}
 
     {{#if cls._class}}
+    {{#unless cls.hideconstructor}}
     <h2>Constructor</h2>
     <!-- Constructor -->
     {{> method obj=cls}}
-    {{/if}}
+    {{/unless}}
+    {{/if}}`
 
     <!--properties-->
     {{#if cls.properties}}

--- a/tmpl/class.tmpl
+++ b/tmpl/class.tmpl
@@ -178,7 +178,7 @@
     <!-- Constructor -->
     {{> method obj=cls}}
     {{/unless}}
-    {{/if}}`
+    {{/if}}
 
     <!--properties-->
     {{#if cls.properties}}


### PR DESCRIPTION
## Added support for `hideconstructor` tag

Fixes https://github.com/playcanvas/engine/issues/2724

Simply render the constructor only if the `@hideconstructor` tag is not set. `@hideconstructor` must be added to the comment block of the enclosing class like so:

```js
/**
 * @class
 * @name Lightmapper
 * @classdesc The lightmapper is used to bake scene lights into textures.
 * ...
 * @hideconstructor 👈 This will hide the constructor
 */
class Lightmapper {
    constructor() { /*...*/ }
    //...
}
``` 