### PR TITLE
Proper link for `@type {this}` to TypeScript documentation

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -265,6 +265,7 @@ var typeLink = function (type) {
         "blob": "https://developer.mozilla.org/en-US/docs/Web/API/Blob",
         "imagedata": "https://developer.mozilla.org/en-US/docs/Web/API/ImageData",
         "imagebitmap": "https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap",
+        "this": "https://www.typescriptlang.org/docs/handbook/advanced-types.html#polymorphic-this-types",
         "*": "#" // blerg
     };
 


### PR DESCRIPTION
In order to fix https://github.com/playcanvas/engine/issues/3995#issuecomment-1036003584 the docs need to support the `this` keyword, otherwise its a 404.

