### PR TITLE
Fix `ul` font size, update dependencies and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@playcanvas/jsdoc-template",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/jsdoc-template",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "MIT",
       "dependencies": {
         "handlebars": "^4.7.7"
       },
       "devDependencies": {
         "@playcanvas/eslint-config": "^1.1.1",
-        "eslint": "^8.15.0",
-        "sass": "^1.51.0",
+        "eslint": "^8.17.0",
+        "sass": "^1.52.3",
         "taffydb": "^2.7.3"
       }
     },
@@ -33,15 +33,15 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
-      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.2",
-        "globals": "^13.9.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -360,12 +360,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
-      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
+      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.3",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -383,7 +383,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
-      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
+      "version": "1.52.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.3.tgz",
+      "integrity": "sha512-LNNPJ9lafx+j1ArtA7GyEJm9eawXN8KlA1+5dF6IZyoONg1Tyo/g+muOsENWJH/2Q1FHbbV4UwliU0cXMa/VIA==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -1313,15 +1313,15 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
-      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.2",
-        "globals": "^13.9.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -1554,12 +1554,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
-      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
+      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.3",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1577,7 +1577,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2075,9 +2075,9 @@
       }
     },
     "sass": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
-      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
+      "version": "1.52.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.3.tgz",
+      "integrity": "sha512-LNNPJ9lafx+j1ArtA7GyEJm9eawXN8KlA1+5dF6IZyoONg1Tyo/g+muOsENWJH/2Q1FHbbV4UwliU0cXMa/VIA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/jsdoc-template",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "JSDoc 3 template for PlayCanvas",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
@@ -38,8 +38,8 @@
   ],
   "devDependencies": {
     "@playcanvas/eslint-config": "^1.1.1",
-    "eslint": "^8.15.0",
-    "sass": "^1.51.0",
+    "eslint": "^8.17.0",
+    "sass": "^1.52.3",
     "taffydb": "^2.7.3"
   },
   "dependencies": {

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -384,6 +384,9 @@ body {
                 font-size: 14px;
                 margin: 0;
             }
+            ul {
+                font-size: 14px;
+            }
             hr {
                 border: 1px solid $hr-color;
                 margin-top: 20px;

--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -396,6 +396,9 @@ body > .container > main p {
   font-size: 14px;
   margin: 0;
 }
+body > .container > main ul {
+  font-size: 14px;
+}
 body > .container > main hr {
   border: 1px solid #F0F0F0;
   margin-top: 20px;


### PR DESCRIPTION
Fixes `ul` font size to be 14px, which changes this:

![image](https://user-images.githubusercontent.com/697563/173028318-d1b661ed-b625-4330-adf3-485399e7f766.png)

To this:

![image](https://user-images.githubusercontent.com/697563/173028225-2d43b1cd-51d1-42b5-995f-867a7418e96d.png)
