### PR TITLE
Fixed inherited properties order

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -172,6 +172,10 @@ function getClassInfo(data, cls) {
             inherited.methods.sort(alphaSort);
             inherited.staticMethods.sort(alphaSort);
             inherited.events.sort(alphaSort);
+
+            if (inherited.cls[i].properties) {
+                inherited.cls[i].properties.sort(alphaSort);
+            }
         }
     }
 


### PR DESCRIPTION
Fixed inherited class properties not being displayed in alphabetical order.