### PR TITLE
Fixed typo

### DIFF
--- a/tmpl/class.hbs
+++ b/tmpl/class.hbs
@@ -17,7 +17,7 @@
 
     <!--type definitions-->
     {{#if typedefs}}
-    <h3>Type Defintions</h3>
+    <h3>Type Definitions</h3>
     <table class="properties">
     {{#each typedefs}}
     <tr>
@@ -146,7 +146,7 @@
 
     <!--type definitions-->
     {{#if typedefs}}
-    <h2>Type Defintions</h2>
+    <h2>Type Definitions</h2>
     {{#each typedefs}}
         {{> typedef obj=this}}
     {{/each}}


### PR DESCRIPTION
Fixed typo for "Type Definition" headers in classes.