### PR TITLE
Minor CI Refinement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+    paths-ignore: ['README.md', 'LICENSE']
   pull_request:
     branches: [ main ]
+    paths-ignore: ['README.md', 'LICENSE']
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Minor CI refinement: dont run CI on readme and license updates, tools don't check them.