### PR TITLE
Support typedefs

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -320,7 +320,7 @@ const typeLink = (type) => {
     const builtin = builtins[name.toLowerCase()];
     if (builtin) {
         url = builtin;
-    } else if (name.endsWith('Callback')) {
+    } else if (name.endsWith('Callback') || realTypedefs[type]) {
         url = `pc.html#${name}`;
     } else {
         url = clsUrl(name);
@@ -448,6 +448,14 @@ var setup = function (opts, callback) {
 };
 
 /**
+ * These are real @typedef's, neither callbacks nor import('abc').xyz
+ * This means they all have at least one property in `properties`.
+ *
+ * @type {Record<string, import('jsdoc').Doclet}
+ */
+const realTypedefs = {};
+
+/**
  * @param {TAFFY} taffyData - See <http://taffydb.com/>.
  * @param {object} opts - Options object.
  * @param {Tutorial} tutorials - Tutorials data.
@@ -472,6 +480,12 @@ exports.publish = (taffyData, opts, tutorials) => {
 
         // Strip all typedefs that are not callbacks
         data(function () {
+            if (this.kind === 'typedef' && !this.name.endsWith('Callback')) {
+                if (this.properties?.length) {
+                    realTypedefs[this.name] = this;
+                    return false;
+                }
+            }
             return this.kind === 'typedef' && !this.name.endsWith('Callback');
         }).remove();
 

--- a/publish.js
+++ b/publish.js
@@ -303,6 +303,14 @@ const builtins = {
     "*": "#" // blerg
 };
 
+/**
+ * These are real @typedef's, neither callbacks nor import('abc').xyz
+ * This means they all have at least one property in `properties`.
+ *
+ * @type {Record<string, import('jsdoc').Doclet}
+ */
+const realTypedefs = {};
+
 // Return an anchor link string from a type
 const typeLink = (type) => {
     // Get the name from string or type object
@@ -446,14 +454,6 @@ var setup = function (opts, callback) {
         }
     });
 };
-
-/**
- * These are real @typedef's, neither callbacks nor import('abc').xyz
- * This means they all have at least one property in `properties`.
- *
- * @type {Record<string, import('jsdoc').Doclet}
- */
-const realTypedefs = {};
 
 /**
  * @param {TAFFY} taffyData - See <http://taffydb.com/>.

--- a/tmpl/typedef.hbs
+++ b/tmpl/typedef.hbs
@@ -15,4 +15,14 @@
         {{/each}}
     </table>
     {{/if}}
+    {{#if obj.properties}}
+    <h4>Properties</h4>
+    <table>
+        {{#each obj.properties}}
+        <tr>
+            <td>{{name}}</td><td>{{{type-link type}}}</td><td>{{{parse description}}}</td>
+        </tr>
+        {{/each}}
+    </table>
+    {{/if}}
 </div>


### PR DESCRIPTION
I wanted to do this for a long time :sweat_smile: 

This allows us to finally declare a typedef like:

```js
/**
 * Animal counting object for a zoo.
 *
 * @typedef {object} AnimalCount
 * @property {number} elephant - The number of elephants.
 * @property {number} dolphins - The number of dolphins.
 */

/**
 * @param {AnimalCount} animalCount - Object containing counts of animal groups.
 * @returns {number} Number of animals.
 */
export function countAllAnimals(animalCount) {
    return animalCount.elephant + animalCount.dolphins;
}
```

And it will be exposed like this in `docs/pc.html`:

![image](https://github.com/playcanvas/playcanvas-jsdoc-template/assets/5236548/b3c25a38-1d6e-4643-affe-18232f9b2218)

If you click on it you see the full definiton:

![image](https://github.com/playcanvas/playcanvas-jsdoc-template/assets/5236548/b0980ed4-a686-497b-a246-4f3394750984)

Having a function that accepts a typedef will also lead you to the correct definition, similar to this scenario:

![image](https://github.com/playcanvas/playcanvas-jsdoc-template/assets/5236548/bf927f86-dce2-4040-8994-9bd801d446f8)

My main motivation is a type issue I found in the engine, basically both `VertexIteratorAccessor` and `VertexFormat` define what a `vertex element` is, but with latest Splat changes we suddenly have one definition differing from the other (there is a new `asInt` property).

(...there are more cases we can use typedefs for to create a better `playcanvas.d.ts`)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
